### PR TITLE
Order#authorize accepts an `Authorization` instance parameter

### DIFF
--- a/lib/paypal-sdk/rest/data_types.rb
+++ b/lib/paypal-sdk/rest/data_types.rb
@@ -942,9 +942,14 @@ module PayPal::SDK
           success?
         end
 
-        def authorize()
+        def authorize(authorization = nil)
+          authorization_body = if authorization.nil?
+                                 self
+                               else
+                                 authorization.is_a?(Authorization) ? authorization : Authorization.new(authorization)
+                               end
           path = "v1/payments/orders/#{self.id}/authorize"
-          response = api.post(path, self.to_hash, http_header)
+          response = api.post(path, authorization_body.to_hash, http_header)
           Authorization.new(response)
         end
 

--- a/spec/payments_examples_spec.rb
+++ b/spec/payments_examples_spec.rb
@@ -297,6 +297,16 @@ describe "Payments" do
         expect(auth.state).to eq("Pending")
       end
 
+      it "Authorize (with amount)", :disabled => true do
+        auth = order.authorize({
+          "amount" => {
+            "currency" => "USD",
+            "total" => "1.00"
+          }
+        })
+        expect(auth.state).to eq("Pending")
+      end
+
       it "Capture", :disabled => true do
         capture = Capture.new({
             "amount" => {


### PR DESCRIPTION
Retain original Order#authorize functionality.